### PR TITLE
install pycharm via umake

### DIFF
--- a/vagrant/provision/setup.sh
+++ b/vagrant/provision/setup.sh
@@ -18,7 +18,9 @@ sudo dpkg-reconfigure debconf -f noninteractive -p critical
 # Java
 sudo apt-add-repository -y ppa:webupd8team/java &>>/var/tmp/vagrant_prov.log
 # PyCharm
-sudo add-apt-repository -y ppa:mystic-mirage/pycharm &>>/var/tmp/vagrant_prov.log
+sudo add-apt-repository -y ppa:ubuntu-desktop/ubuntu-make
+sudo apt-get update
+sudo apt-get install -y ubuntu-make
 # ROS
 sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
 sudo apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key 0xB01FA116 &>>/var/tmp/vagrant_prov.log
@@ -62,7 +64,7 @@ sudo apt-get install -y -qq oracle-java8-installer &>>/var/tmp/vagrant_prov.log
 
 ## Install PyCharm (Python IDE)
 sudo echo "Installing PyCharm (Python IDE)" | tee -a /var/tmp/vagrant_prov.log
-sudo apt-get install -y -qq pycharm-community &>>/var/tmp/vagrant_prov.log
+umake ide pycharm &>>/var/tmp/vagrant_prov.log
 
 ## Install ROS
 sudo echo "Installing ROS (the robot OS)" | tee -a /var/tmp/vagrant_prov.log


### PR DESCRIPTION
The ppa method of installation of pycharm is obsolete.
https://launchpad.net/~mystic-mirage/+archive/ubuntu/pycharm

New method applied to the provisioning script
https://itsfoss.com/install-pycharm-ubuntu/