### PR TITLE
Address issue #7.

### DIFF
--- a/vagrant/provision/setup.sh
+++ b/vagrant/provision/setup.sh
@@ -80,11 +80,6 @@ sudo apt-get install -y python-rosinstall &>>/var/tmp/vagrant_prov.log
 
 sudo apt-get install -y ros-jade-rosbridge-server &>>/var/tmp/vagrant_prov.log
 
-# Install gazebo
-sudo echo "Installing Gazebo (3d simulation environment)" | tee -a /var/tmp/vagrant_prov.log
-sudo apt-get install -y gazebo5 &>>/var/tmp/vagrant_prov.log
-sudo apt-get install -y ros-jade-gazebo-ros-pkgs &>>/var/tmp/vagrant_prov.log
-
 #####################
 # Setup environment #
 #####################


### PR DESCRIPTION
Remove apt-get installation for gazebo5 and  ros-jade-gazebo-ros-pkgs, which is redundant with ros jade desktop full installation.